### PR TITLE
Solución Implicit conversion PHP > 8

### DIFF
--- a/src/Rut.php
+++ b/src/Rut.php
@@ -244,7 +244,7 @@ class Rut
         $rut = $this->number;
         $s=1;
         for ($m=0; $rut != 0; $rut /= 10) {
-            $s=($s+$rut % 10 * (9-$m++%6))%11;
+            $s=((int)$s+(int)$rut % (int)10 * ((int)9-(int)$m++%(int)6))%(int)11;
         }
         return chr($s?$s+47:75);
     }


### PR DESCRIPTION
Solucion para php 8 en adelante que genera warnings en el calculo del digito verificador 
(Implicit conversion from float XXXXXXXXE-62 to int loses precision)
Las X Son numero que fueron reemplazados.