### PR TITLE
Agrega validación explícita para parámetros nullables #17

### DIFF
--- a/src/Rut.php
+++ b/src/Rut.php
@@ -169,7 +169,7 @@ class Rut
      * @param array $chars
      * @return $this|array
      */
-    public function scape_chars(array $chars = null)
+    public function scape_chars(?array $chars = null)
     {
         if ($chars !== null) {
             $this->escapeChars = $chars;
@@ -183,7 +183,7 @@ class Rut
      * @param array|null $vnSeparator
      * @return $this|string
      */
-    public function vnSeparator(array $vnSeparator = null)
+    public function vnSeparator(?array $vnSeparator = null)
     {
         if ($vnSeparator !== null) {
             $this->vnSeparator = $vnSeparator;


### PR DESCRIPTION
Issue: #17 

Este PR realiza los siguientes cambios:

- Corrige la advertencia "Implicitly nullable parameters are deprecated" declarando explícitamente el tipo nullable (`?array`) en el método `vnSeparator`.
- Mejora la compatibilidad con versiones recientes de PHP (8.1+).
- Mejora la legibilidad del código y evita posibles errores futuros.

Este cambio es retrocompatible y no afecta la funcionalidad existente.